### PR TITLE
update org.clojure/tools.logging 1.1.0 -> 1.2.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,8 +4,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.3"]
-                 [org.clojure/tools.logging "1.1.0"]
-                 [clj-antlr "0.2.9"]]
+                 [org.clojure/tools.logging "1.2.3"]
+                 [clj-antlr "0.2.10"]]
 
   :min-lein-version "2.9.1"
   :pedantic :abort)


### PR DESCRIPTION
To be save against log4shell, even when used with log4j.
tools.logging uses log4j 2.17 as dev-dependency.